### PR TITLE
add presentations

### DIFF
--- a/src/pages/construction.mdx
+++ b/src/pages/construction.mdx
@@ -4,6 +4,13 @@ title: Construction
 ---
 
 # M3 - Construction
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%;
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden;
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;"
+    src="https://www.canva.com/design/DAGj589ywbk/r-lkONRyU1xM08ChTgKImw/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
 
 ## Updated Architecture
 

--- a/src/pages/elaboration.mdx
+++ b/src/pages/elaboration.mdx
@@ -5,6 +5,14 @@ title: Elaboration
 
 # M2 - Elaboration
 
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%;
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden;
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;"
+    src="https://www.canva.com/design/DAGg-vAcoOk/3dUXHu0imF3g62kkPfGWsQ/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
+
 ## State-of-the-art
 
 ### Selected Features

--- a/src/pages/inception.mdx
+++ b/src/pages/inception.mdx
@@ -4,6 +4,13 @@ title: Inception
 ---
 
 # M1 - Inception
+<div style="position: relative; width: 100%; height: 0; padding-top: 56.2500%;
+ padding-bottom: 0; box-shadow: 0 2px 8px 0 rgba(63,69,81,0.16); margin-top: 1.6em; margin-bottom: 0.9em; overflow: hidden;
+ border-radius: 8px; will-change: transform;">
+  <iframe loading="lazy" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; border: none; padding: 0;margin: 0;"
+    src="https://www.canva.com/design/DAGfdp2D1Lk/z01AkPxQ_J8-p7WBZJJs-g/view?embed" allowfullscreen="allowfullscreen" allow="fullscreen">
+  </iframe>
+</div>
 
 ## Project Overview
 


### PR DESCRIPTION
This pull request adds embedded Canva designs to the `Inception`, `Elaboration`, and `Construction` pages in the documentation. The changes enhance the visual presentation by embedding interactive content using iframes.

### Embedded Canva Designs:

* [`src/pages/inception.mdx`](diffhunk://#diff-47d2bcb2fca30be7db8d2494a87acf48986c42ac5a065d2068723cff3fb71795R7-R13): Added an iframe embedding a Canva design to the `Inception` page for improved visual representation.
* [`src/pages/elaboration.mdx`](diffhunk://#diff-1c2dac525933f912f5e72bfd4f9ead5170059021834fc79b644e02b81e8a7473R8-R15): Embedded a Canva design in the `Elaboration` page using an iframe to enhance the content's interactivity.
* [`src/pages/construction.mdx`](diffhunk://#diff-edc6d659c40653ea781771fb704a06e213bb58b13fe25b2768c2eb4cd472760dR7-R13): Included an iframe with a Canva design in the `Construction` page to enrich the visual content.